### PR TITLE
fixes in main pool, make it work-stealing, add simple pool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   run:
     name: build
+    timeout-minutes: 10
     strategy:
       fail-fast: true
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BENCH_CUTOFF?=20
 bench-fib:
 	@echo running for N=$(N)
 	dune build $(DUNE_OPTS_BENCH) benchs/fib_rec.exe
-	hyperfine -L psize $(BENCH_PSIZE) \
+	hyperfine -L psize $(BENCH_PSIZE) --warmup=1 \
 		'./_build/default/benchs/fib_rec.exe -cutoff $(BENCH_CUTOFF) -niter $(NITER) -psize={psize} -n $(N)'
 
 PI_NSTEPS?=100_000_000
@@ -36,7 +36,7 @@ PI_MODES?=seq,par1,forkjoin
 bench-pi:
 	@echo running for N=$(PI_NSTEPS)
 	dune build $(DUNE_OPTS_BENCH) benchs/pi.exe
-	hyperfine -L mode $(PI_MODES) \
+	hyperfine -L mode $(PI_MODES) --warmup=1 \
 		'./_build/default/benchs/pi.exe -mode={mode} -n $(PI_NSTEPS)'
 
 .PHONY: test clean bench-fib bench-pi

--- a/Makefile
+++ b/Makefile
@@ -22,22 +22,24 @@ watch:
 DUNE_OPTS_BENCH?=--profile=release
 
 N?=40
-NITER?=3
+NITER?=2
 BENCH_PSIZE?=1,4,8,20
+BENCH_KIND?=simple,pool
 BENCH_CUTOFF?=20
 bench-fib:
 	@echo running for N=$(N)
 	dune build $(DUNE_OPTS_BENCH) benchs/fib_rec.exe
-	hyperfine -L psize $(BENCH_PSIZE) --warmup=1 \
-		'./_build/default/benchs/fib_rec.exe -cutoff $(BENCH_CUTOFF) -niter $(NITER) -psize={psize} -n $(N)'
+	hyperfine -L psize $(BENCH_PSIZE) -L kind $(BENCH_KIND) --warmup=1 \
+		'./_build/default/benchs/fib_rec.exe -cutoff $(BENCH_CUTOFF) -niter $(NITER) -psize={psize} -kind={kind} -n $(N)'
 
 PI_NSTEPS?=100_000_000
 PI_MODES?=seq,par1,forkjoin
+PI_KIND?=simple,pool
 bench-pi:
 	@echo running for N=$(PI_NSTEPS)
 	dune build $(DUNE_OPTS_BENCH) benchs/pi.exe
-	hyperfine -L mode $(PI_MODES) --warmup=1 \
-		'./_build/default/benchs/pi.exe -mode={mode} -n $(PI_NSTEPS)'
+	hyperfine -L mode $(PI_MODES) -L kind $(PI_KIND) --warmup=1 \
+		'./_build/default/benchs/pi.exe -mode={mode} -kind={kind} -n $(PI_NSTEPS)'
 
 .PHONY: test clean bench-fib bench-pi
 

--- a/benchs/dune
+++ b/benchs/dune
@@ -3,4 +3,4 @@
  (names fib_rec pi)
  (preprocess (action
    (run %{project_root}/src/cpp/cpp.exe %{input-file})))
- (libraries moonpool unix))
+ (libraries moonpool unix trace trace-tef))

--- a/benchs/fib_rec.ml
+++ b/benchs/fib_rec.ml
@@ -31,7 +31,8 @@ let run ~psize ~n ~seq ~niter () : unit =
       )
     in
     Printf.printf "fib %d = %d\n%!" n res
-  done
+  done;
+  if not seq then Pool.shutdown (Lazy.force pool)
 
 let () =
   let n = ref 40 in

--- a/benchs/pi.ml
+++ b/benchs/pi.ml
@@ -17,15 +17,23 @@ let run_sequential (num_steps : int) : float =
   pi
 
 (** Create a pool *)
-let with_pool f =
-  if !j = 0 then
-    Pool.with_ ~per_domain:1 f
-  else
-    Pool.with_ ~min:!j f
+let with_pool ~kind f =
+  match kind with
+  | "pool" ->
+    if !j = 0 then
+      Pool.with_ ~per_domain:1 f
+    else
+      Pool.with_ ~min:!j f
+  | "simple" ->
+    if !j = 0 then
+      Simple_pool.with_ ~per_domain:1 f
+    else
+      Simple_pool.with_ ~min:!j f
+  | _ -> assert false
 
 (** Run in parallel using {!Fut.for_} *)
-let run_par1 (num_steps : int) : float =
-  let@ pool = with_pool () in
+let run_par1 ~kind (num_steps : int) : float =
+  let@ pool = with_pool ~kind () in
 
   let num_tasks = Pool.size pool in
 
@@ -53,8 +61,8 @@ let run_par1 (num_steps : int) : float =
 
 [@@@ifge 5.0]
 
-let run_fork_join num_steps : float =
-  let@ pool = with_pool () in
+let run_fork_join ~kind num_steps : float =
+  let@ pool = with_pool ~kind () in
 
   let num_tasks = Pool.size pool in
 
@@ -90,9 +98,11 @@ type mode =
   | Fork_join
 
 let () =
+  let@ () = Trace_tef.with_setup () in
   let mode = ref Sequential in
   let n = ref 1000 in
   let time = ref false in
+  let kind = ref "pool" in
 
   let set_mode = function
     | "seq" -> mode := Sequential
@@ -109,6 +119,9 @@ let () =
         " mode of execution" );
       "-j", Arg.Set_int j, " number of threads";
       "-t", Arg.Set time, " printing timing";
+      ( "-kind",
+        Arg.Symbol ([ "pool"; "simple" ], ( := ) kind),
+        " pick pool implementation" );
     ]
     |> Arg.align
   in
@@ -118,8 +131,8 @@ let () =
   let res =
     match !mode with
     | Sequential -> run_sequential !n
-    | Par1 -> run_par1 !n
-    | Fork_join -> run_fork_join !n
+    | Par1 -> run_par1 ~kind:!kind !n
+    | Fork_join -> run_fork_join ~kind:!kind !n
   in
   let elapsed : float = Unix.gettimeofday () -. t_start in
 

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@
   dune
   (either (>= 1.0))
   (trace :with-test)
+  (trace-tef :with-test)
   (qcheck-core (and :with-test (>= 0.19)))
   (odoc :with-doc)
   (mdx

--- a/moonpool.opam
+++ b/moonpool.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {>= "3.0"}
   "either" {>= "1.0"}
   "trace" {with-test}
+  "trace-tef" {with-test}
   "qcheck-core" {with-test & >= "0.19"}
   "odoc" {with-doc}
   "mdx" {>= "1.9.0" & with-test}

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name moonpool)
  (name moonpool)
- (private_modules d_pool_)
+ (private_modules d_pool_ dla_)
  (preprocess
   (action
    (run %{project_root}/src/cpp/cpp.exe %{input-file})))

--- a/src/moonpool.ml
+++ b/src/moonpool.ml
@@ -11,4 +11,9 @@ module Fut = Fut
 module Lock = Lock
 module Pool = Pool
 module Runner = Runner
-module Suspend_ = Suspend_
+module Simple_pool = Simple_pool
+
+module Private = struct
+  module Ws_deque_ = Ws_deque_
+  module Suspend_ = Suspend_
+end

--- a/src/moonpool.mli
+++ b/src/moonpool.mli
@@ -5,6 +5,7 @@
 *)
 
 module Pool = Pool
+module Simple_pool = Simple_pool
 module Runner = Runner
 
 val start_thread_on_some_domain : ('a -> unit) -> 'a -> Thread.t
@@ -141,12 +142,19 @@ module Atomic = Atomic_
     This is either a shim using [ref], on pre-OCaml 5, or the
     standard [Atomic] module on OCaml 5. *)
 
-(** {2 Suspensions} *)
+(**/**)
 
-module Suspend_ = Suspend_
-[@@alert unstable "this module is an implementation detail of moonpool for now"]
-(** Suspensions.
+module Private : sig
+  module Ws_deque_ = Ws_deque_
+
+  (** {2 Suspensions} *)
+
+  module Suspend_ = Suspend_
+  [@@alert
+    unstable "this module is an implementation detail of moonpool for now"]
+  (** Suspensions.
 
     This is only going to work on OCaml 5.x.
 
     {b NOTE}: this is not stable for now. *)
+end

--- a/src/pool.mli
+++ b/src/pool.mli
@@ -23,11 +23,6 @@ type thread_loop_wrapper =
       By default it just returns the same loop function but it can be used
       to install tracing, effect handlers, etc. *)
 
-val add_global_thread_loop_wrapper : thread_loop_wrapper -> unit
-(** [add_global_thread_loop_wrapper f] installs [f] to be installed in every new pool worker
-      thread, for all existing pools, and all new pools created with [create].
-      These wrappers accumulate: they all apply, but their order is not specified. *)
-
 type ('a, 'b) create_args =
   ?on_init_thread:(dom_id:int -> t_id:int -> unit -> unit) ->
   ?on_exit_thread:(dom_id:int -> t_id:int -> unit -> unit) ->

--- a/src/simple_pool.ml
+++ b/src/simple_pool.ml
@@ -1,0 +1,161 @@
+include Runner
+
+let ( let@ ) = ( @@ )
+
+type state = {
+  threads: Thread.t array;
+  q: task Bb_queue.t;  (** Queue for tasks. *)
+}
+(** internal state *)
+
+let[@inline] size_ (self : state) = Array.length self.threads
+let[@inline] num_tasks_ (self : state) : int = Bb_queue.size self.q
+
+(** Run [task] as is, on the pool. *)
+let run_direct_ (self : state) (task : task) : unit = Bb_queue.push self.q task
+
+let rec run_async_ (self : state) (task : task) : unit =
+  let task' () =
+    (* run [f()] and handle [suspend] in it *)
+    Suspend_.with_suspend task ~run:(fun ~with_handler task ->
+        if with_handler then
+          run_async_ self task
+        else
+          run_direct_ self task)
+  in
+  run_direct_ self task'
+
+type around_task = AT_pair : (t -> 'a) * (t -> 'a -> unit) -> around_task
+
+let worker_thread_ (self : state) (runner : t) ~on_exn ~around_task : unit =
+  let (AT_pair (before_task, after_task)) = around_task in
+
+  let run_task task : unit =
+    let _ctx = before_task runner in
+    (* run the task now, catching errors *)
+    (try task ()
+     with e ->
+       let bt = Printexc.get_raw_backtrace () in
+       on_exn e bt);
+    after_task runner _ctx
+  in
+
+  let main_loop () =
+    let continue = ref true in
+    while !continue do
+      match Bb_queue.pop self.q with
+      | task -> run_task task
+      | exception Bb_queue.Closed -> continue := false
+    done
+  in
+
+  try
+    (* handle domain-local await *)
+    Dla_.using ~prepare_for_await:Suspend_.prepare_for_await
+      ~while_running:main_loop
+  with Bb_queue.Closed -> ()
+
+let default_thread_init_exit_ ~dom_id:_ ~t_id:_ () = ()
+
+let shutdown_ ~wait (self : state) : unit =
+  Bb_queue.close self.q;
+  if wait then Array.iter Thread.join self.threads
+
+type ('a, 'b) create_args =
+  ?on_init_thread:(dom_id:int -> t_id:int -> unit -> unit) ->
+  ?on_exit_thread:(dom_id:int -> t_id:int -> unit -> unit) ->
+  ?on_exn:(exn -> Printexc.raw_backtrace -> unit) ->
+  ?around_task:(t -> 'b) * (t -> 'b -> unit) ->
+  ?min:int ->
+  ?per_domain:int ->
+  'a
+
+let create ?(on_init_thread = default_thread_init_exit_)
+    ?(on_exit_thread = default_thread_init_exit_) ?(on_exn = fun _ _ -> ())
+    ?around_task ?min:(min_threads = 1) ?(per_domain = 0) () : t =
+  (* wrapper *)
+  let around_task =
+    match around_task with
+    | Some (f, g) -> AT_pair (f, g)
+    | None -> AT_pair (ignore, fun _ _ -> ())
+  in
+
+  (* number of threads to run *)
+  let min_threads = max 1 min_threads in
+  let num_domains = D_pool_.n_domains () in
+  assert (num_domains >= 1);
+  let num_threads = max min_threads (num_domains * per_domain) in
+
+  (* make sure we don't bias towards the first domain(s) in {!D_pool_} *)
+  let offset = Random.int num_domains in
+
+  let pool =
+    let dummy = Thread.self () in
+    { threads = Array.make num_threads dummy; q = Bb_queue.create () }
+  in
+
+  let runner =
+    Runner.For_runner_implementors.create
+      ~shutdown:(fun ~wait () -> shutdown_ pool ~wait)
+      ~run_async:(fun f -> run_async_ pool f)
+      ~size:(fun () -> size_ pool)
+      ~num_tasks:(fun () -> num_tasks_ pool)
+      ()
+  in
+
+  (* temporary queue used to obtain thread handles from domains
+     on which the thread are started. *)
+  let receive_threads = Bb_queue.create () in
+
+  (* start the thread with index [i] *)
+  let start_thread_with_idx i =
+    let dom_idx = (offset + i) mod num_domains in
+
+    (* function run in the thread itself *)
+    let main_thread_fun () : unit =
+      let thread = Thread.self () in
+      let t_id = Thread.id thread in
+      on_init_thread ~dom_id:dom_idx ~t_id ();
+
+      let run () = worker_thread_ pool runner ~on_exn ~around_task in
+
+      (* now run the main loop *)
+      Fun.protect run ~finally:(fun () ->
+          (* on termination, decrease refcount of underlying domain *)
+          D_pool_.decr_on dom_idx);
+      on_exit_thread ~dom_id:dom_idx ~t_id ()
+    in
+
+    (* function called in domain with index [i], to
+       create the thread and push it into [receive_threads] *)
+    let create_thread_in_domain () =
+      let thread = Thread.create main_thread_fun () in
+      (* send the thread from the domain back to us *)
+      Bb_queue.push receive_threads (i, thread)
+    in
+
+    D_pool_.run_on dom_idx create_thread_in_domain
+  in
+
+  (* start all threads, placing them on the domains
+     according to their index and [offset] in a round-robin fashion. *)
+  for i = 0 to num_threads - 1 do
+    start_thread_with_idx i
+  done;
+
+  (* receive the newly created threads back from domains *)
+  for _j = 1 to num_threads do
+    let i, th = Bb_queue.pop receive_threads in
+    pool.threads.(i) <- th
+  done;
+
+  runner
+
+let with_ ?on_init_thread ?on_exit_thread ?on_exn ?around_task ?min ?per_domain
+    () f =
+  let pool =
+    create ?on_init_thread ?on_exit_thread ?on_exn ?around_task ?min ?per_domain
+      ()
+  in
+  let@ () = Fun.protect ~finally:(fun () -> shutdown pool) in
+  f pool

--- a/src/simple_pool.mli
+++ b/src/simple_pool.mli
@@ -1,0 +1,36 @@
+(** A simple thread pool.
+
+    This uses a single blocking queue to manage tasks, it's very
+    simple and reliable. Like {!Pool} it distributes a fixed number
+    of workers over several domains.
+
+    @since NEXT_RELEASE *)
+
+include module type of Runner
+
+type ('a, 'b) create_args =
+  ?on_init_thread:(dom_id:int -> t_id:int -> unit -> unit) ->
+  ?on_exit_thread:(dom_id:int -> t_id:int -> unit -> unit) ->
+  ?on_exn:(exn -> Printexc.raw_backtrace -> unit) ->
+  ?around_task:(t -> 'b) * (t -> 'b -> unit) ->
+  ?min:int ->
+  ?per_domain:int ->
+  'a
+(** Arguments used in {!create}. See {!create} for explanations. *)
+
+val create : (unit -> t, _) create_args
+(** [create ()] makes a new thread pool.
+     @param on_init_thread called at the beginning of each new thread in the pool.
+     @param min minimum size of the pool. See {!Pool.create_args}.
+     @param per_domain is the number of threads allocated per domain in the fixed
+       domain pool. See {!Pool.create_args}.
+     @param on_exit_thread called at the end of each worker thread in the pool.
+     @param around_task a pair of [before, after] functions
+     ran around each task. See {!Pool.create_args}.
+  *)
+
+val with_ : (unit -> (t -> 'a) -> 'a, _) create_args
+(** [with_ () f] calls [f pool], where [pool] is obtained via {!create}.
+    When [f pool] returns or fails, [pool] is shutdown and its resources
+    are released.
+    Most parameters are the same as in {!create}. *)

--- a/src/suspend_.mli
+++ b/src/suspend_.mli
@@ -50,6 +50,9 @@ val suspend : suspension_handler -> unit
 
 [@@@endif]
 
+val prepare_for_await : unit -> Dla_.t
+(** Our stub for DLA. Unstable. *)
+
 val with_suspend :
   run:(with_handler:bool -> task -> unit) -> (unit -> unit) -> unit
 (** [with_suspend ~run f] runs [f()] in an environment where [suspend]

--- a/src/ws_deque_.ml
+++ b/src/ws_deque_.ml
@@ -1,0 +1,107 @@
+module A = Atomic_
+
+(* terminology:
+
+   - Bottom: where we push/pop normally. Only one thread can do that.
+   - top: where work stealing happens (older values).
+     This only ever grows.
+
+   Elements are always added on the bottom end. *)
+
+(** Circular array (size is [2 ^ log_size]) *)
+module CA : sig
+  type 'a t
+
+  val create : log_size:int -> unit -> 'a t
+  val size : _ t -> int
+  val get : 'a t -> int -> 'a
+  val set : 'a t -> int -> 'a -> unit
+  val grow : 'a t -> bottom:int -> top:int -> 'a t
+end = struct
+  type 'a t = {
+    log_size: int;
+    arr: 'a option array;
+  }
+
+  let[@inline] size (self : _ t) = 1 lsl self.log_size
+
+  let create ~log_size () : _ t =
+    { log_size; arr = Array.make (1 lsl log_size) None }
+
+  let[@inline] get (self : _ t) (i : int) : 'a =
+    match Array.unsafe_get self.arr (i mod size self) with
+    | Some x -> x
+    | None -> assert false
+
+  let[@inline] set (self : 'a t) (i : int) (x : 'a) : unit =
+    Array.unsafe_set self.arr (i mod size self) (Some x)
+
+  let grow (self : _ t) ~bottom ~top : 'a t =
+    let new_arr = create ~log_size:(self.log_size + 1) () in
+    for i = top to bottom - 1 do
+      set new_arr i (get self i)
+    done;
+    new_arr
+end
+
+type 'a t = {
+  top: int A.t;  (** Where we steal *)
+  bottom: int A.t;  (** Where we push/pop from the owning thread *)
+  mutable arr: 'a CA.t;  (** The circular array *)
+}
+
+let create () : _ t =
+  let arr = CA.create ~log_size:4 () in
+  { top = A.make 0; bottom = A.make 0; arr }
+
+let[@inline] size (self : _ t) : int = max 0 (A.get self.bottom - A.get self.top)
+
+let push (self : 'a t) (x : 'a) : unit =
+  let b = A.get self.bottom in
+  let t = A.get self.top in
+  let size = b - t in
+
+  if size >= CA.size self.arr - 1 then
+    self.arr <- CA.grow self.arr ~top:t ~bottom:b;
+
+  CA.set self.arr b x;
+  A.set self.bottom (b + 1)
+
+let pop (self : 'a t) : 'a option =
+  let b = A.get self.bottom in
+  let arr = self.arr in
+  let b = b - 1 in
+  A.set self.bottom b;
+  let t = A.get self.top in
+  let size = b - t in
+  if size < 0 then (
+    A.set self.bottom t;
+    None
+  ) else if size > 0 then (
+    let x = CA.get arr b in
+    Some x
+  ) else if A.compare_and_set self.top t (t + 1) then (
+    (* exactly one slot, so we might be racing against stealers
+       to update [self.top] *)
+    let x = CA.get arr b in
+    A.set self.bottom (t + 1);
+    Some x
+  ) else
+    None
+
+let steal (self : 'a t) : 'a option =
+  let t = A.get self.top in
+  let b = A.get self.bottom in
+  let arr = self.arr in
+
+  let size = b - t in
+  if size <= 0 then
+    None
+  else (
+    let x = CA.get arr t in
+    if A.compare_and_set self.top t (t + 1) then
+      (* successfully increased top to consume [x] *)
+      Some x
+    else
+      None
+  )

--- a/src/ws_deque_.mli
+++ b/src/ws_deque_.mli
@@ -1,0 +1,21 @@
+(** Work-stealing deque.
+
+  Adapted from "Dynamic circular work stealing deque", Chase & Lev
+  *)
+
+type 'a t
+(** Deque containing values of type ['a] *)
+
+val create : unit -> _ t
+(** Create a new deque. *)
+
+val push : 'a t -> 'a -> unit
+(** Push value at the bottom of deque. This is not thread-safe. *)
+
+val pop : 'a t -> 'a option
+(** Pop value from the bottom of deque. This is not thread-safe. *)
+
+val steal : 'a t -> 'a option
+(** Try to steal from the top of deque. This is thread-safe. *)
+
+val size : _ t -> int

--- a/test/dune
+++ b/test/dune
@@ -8,10 +8,13 @@
   t_props
   t_chan_train
   t_resource
+  t_unfair
   t_bounded_queue)
  (libraries
   moonpool
   qcheck-core
   qcheck-core.runner
   ;tracy-client.trace
+  unix
+  trace-tef
   trace))

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,7 @@
   t_chan_train
   t_resource
   t_unfair
+  t_ws_deque
   t_bounded_queue)
  (libraries
   moonpool

--- a/test/effect-based/dune
+++ b/test/effect-based/dune
@@ -1,11 +1,11 @@
 
 (tests
   (names t_fib1 t_futs1 t_many t_fib_fork_join
-         t_fib_fork_join_all t_sort t_fork_join)
+         t_fib_fork_join_all t_sort t_fork_join t_fork_join_heavy)
   (preprocess (action
    (run %{project_root}/src/cpp/cpp.exe %{input-file})))
   (enabled_if (>= %{ocaml_version} 5.0))
-  (libraries moonpool trace
+  (libraries moonpool trace trace-tef
              qcheck-core qcheck-core.runner
              ;tracy-client.trace
              ))

--- a/test/effect-based/t_fork_join.ml
+++ b/test/effect-based/t_fork_join.ml
@@ -326,15 +326,15 @@ let t_map ~chunk_size () =
 let () =
   QCheck_base_runner.run_tests_main
     [
-      t_eval;
-      t_map ~chunk_size:1 ();
-      t_map ~chunk_size:50 ();
-      t_for_nested ~min:1 ~chunk_size:1 ();
-      t_for_nested ~min:4 ~chunk_size:1 ();
-      t_for_nested ~min:1 ~chunk_size:3 ();
-      t_for_nested ~min:4 ~chunk_size:3 ();
+      (* t_eval; *)
+      (* t_map ~chunk_size:1 (); *)
+      (* t_map ~chunk_size:50 (); *)
+      (* t_for_nested ~min:1 ~chunk_size:1 (); *)
+      (* t_for_nested ~min:4 ~chunk_size:1 (); *)
+      (* t_for_nested ~min:1 ~chunk_size:3 (); *)
+      (* t_for_nested ~min:4 ~chunk_size:3 (); *)
       t_for_nested ~min:1 ~chunk_size:100 ();
-      t_for_nested ~min:4 ~chunk_size:100 ();
+      (* t_for_nested ~min:4 ~chunk_size:100 (); *)
     ]
 
 [@@@endif]

--- a/test/effect-based/t_fork_join.ml
+++ b/test/effect-based/t_fork_join.ml
@@ -326,15 +326,15 @@ let t_map ~chunk_size () =
 let () =
   QCheck_base_runner.run_tests_main
     [
-      (* t_eval; *)
-      (* t_map ~chunk_size:1 (); *)
-      (* t_map ~chunk_size:50 (); *)
-      (* t_for_nested ~min:1 ~chunk_size:1 (); *)
-      (* t_for_nested ~min:4 ~chunk_size:1 (); *)
-      (* t_for_nested ~min:1 ~chunk_size:3 (); *)
-      (* t_for_nested ~min:4 ~chunk_size:3 (); *)
+      t_eval;
+      t_map ~chunk_size:1 ();
+      t_map ~chunk_size:50 ();
+      t_for_nested ~min:1 ~chunk_size:1 ();
+      t_for_nested ~min:4 ~chunk_size:1 ();
+      t_for_nested ~min:1 ~chunk_size:3 ();
+      t_for_nested ~min:4 ~chunk_size:3 ();
       t_for_nested ~min:1 ~chunk_size:100 ();
-      (* t_for_nested ~min:4 ~chunk_size:100 (); *)
+      t_for_nested ~min:4 ~chunk_size:100 ();
     ]
 
 [@@@endif]

--- a/test/effect-based/t_fork_join_heavy.ml
+++ b/test/effect-based/t_fork_join_heavy.ml
@@ -1,0 +1,57 @@
+[@@@ifge 5.0]
+
+module Q = QCheck
+
+let spf = Printf.sprintf
+let ( let@ ) = ( @@ )
+let ppl = Q.Print.(list @@ list int)
+
+open! Moonpool
+
+let run ~min () =
+  let@ _sp =
+    Trace.with_span ~__FILE__ ~__LINE__ "run" ~data:(fun () ->
+        [ "min", `Int min ])
+  in
+
+  Printf.printf "run with min=%d\n%!" min;
+  let neg x = -x in
+
+  let chunk_size = 100 in
+  let l = List.init 300 (fun _ -> List.init 15 (fun i -> i)) in
+
+  let ref_l1 = List.map (List.map neg) l in
+  let ref_l2 = List.map (List.map neg) ref_l1 in
+
+  for _i = 1 to 800 do
+    let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "step" in
+
+    let l1, l2 =
+      let@ pool = Pool.with_ ~min () in
+      let@ () = Pool.run_wait_block pool in
+
+      let l1, l2 =
+        Fork_join.both
+          (fun () ->
+            Fork_join.map_list ~chunk_size
+              (Fork_join.map_list ~chunk_size neg)
+              l)
+          (fun () ->
+            Fork_join.map_list ~chunk_size
+              (Fork_join.map_list ~chunk_size neg)
+              ref_l1)
+      in
+      l1, l2
+    in
+
+    if l1 <> ref_l1 then failwith (spf "l1=%s, ref_l1=%s" (ppl l1) (ppl ref_l1));
+    if l2 <> ref_l2 then failwith (spf "l1=%s, ref_l1=%s" (ppl l2) (ppl ref_l2))
+  done
+
+let () =
+  let@ () = Trace_tef.with_setup () in
+  run ~min:4 ();
+  run ~min:1 ();
+  Printf.printf "done\n%!"
+
+[@@@endif]

--- a/test/effect-based/t_many.ml
+++ b/test/effect-based/t_many.ml
@@ -2,9 +2,10 @@
 
 open Moonpool
 
-let pool = Pool.create ~min:4 ()
+let ( let@ ) = ( @@ )
 
 let run () =
+  let@ pool = Pool.with_ ~min:4 () in
   let t1 = Unix.gettimeofday () in
 
   let n = 200_000 in

--- a/test/t_fib.ml
+++ b/test/t_fib.ml
@@ -1,5 +1,12 @@
 open Moonpool
 
+let ( let@ ) = ( @@ )
+
+let with_pool ~kind () f =
+  match kind with
+  | `Simple_pool -> Simple_pool.with_ ~min:4 () f
+  | `Pool -> Pool.with_ ~min:4 () f
+
 let rec fib x =
   if x <= 1 then
     1
@@ -8,8 +15,7 @@ let rec fib x =
 
 let () = assert (List.init 10 fib = [ 1; 1; 2; 3; 5; 8; 13; 21; 34; 55 ])
 
-let run_test () =
-  let pool = Pool.create ~min:4 () in
+let run_test ~pool () =
   let fibs = Array.init 30 (fun n -> Fut.spawn ~on:pool (fun () -> fib n)) in
   let res = Fut.join_array fibs |> Fut.wait_block in
   Pool.shutdown pool;
@@ -50,11 +56,23 @@ let run_test () =
           832040;
         |])
 
-let () =
+let run ~kind () =
   for _i = 1 to 4 do
-    run_test ()
+    let@ pool = with_pool ~kind () in
+    run_test ~pool ()
   done;
 
   (* now make sure we can do this with multiple pools in parallel *)
-  let jobs = Array.init 4 (fun _ -> Thread.create run_test ()) in
+  let jobs =
+    Array.init 4 (fun _ ->
+        Thread.create
+          (fun () ->
+            let@ pool = with_pool ~kind () in
+            run_test ~pool ())
+          ())
+  in
   Array.iter Thread.join jobs
+
+let () =
+  run ~kind:`Pool ();
+  run ~kind:`Simple_pool ()

--- a/test/t_props.ml
+++ b/test/t_props.ml
@@ -1,49 +1,54 @@
 module Q = QCheck
 open Moonpool
 
+let ( let@ ) = ( @@ )
 let tests = ref []
 let add_test t = tests := t :: !tests
 
-(* main pool *)
-let pool = Pool.create ~min:4 ~per_domain:1 ()
-
-(* pool for future combinators *)
-let pool_fut = Pool.create ~min:2 ()
-
-module Fut2 = (val Fut.infix pool_fut)
+let with_pool ~kind () f =
+  match kind with
+  | `Simple_pool -> Simple_pool.with_ ~min:4 ~per_domain:1 () f
+  | `Pool -> Pool.with_ ~min:4 ~per_domain:1 () f
 
 let () =
-  add_test
-  @@ Q.Test.make ~name:"map then join_list"
-       Q.(small_list small_int)
-       (fun l ->
-         let l' = List.map (fun x -> Fut.spawn ~on:pool (fun () -> x + 1)) l in
-         let l' = Fut.join_list l' |> Fut.wait_block_exn in
-         if l' <> List.map succ l then Q.Test.fail_reportf "bad list";
-         true)
+  add_test @@ fun ~kind ->
+  let@ pool = with_pool ~kind () in
+  Q.Test.make ~name:"map then join_list"
+    Q.(small_list small_int)
+    (fun l ->
+      let l' = List.map (fun x -> Fut.spawn ~on:pool (fun () -> x + 1)) l in
+      let l' = Fut.join_list l' |> Fut.wait_block_exn in
+      if l' <> List.map succ l then Q.Test.fail_reportf "bad list";
+      true)
 
 let () =
-  add_test
-  @@ Q.Test.make ~name:"map bind"
-       Q.(small_list small_int)
-       (fun l ->
-         let open Fut2 in
-         let l' =
-           l
-           |> List.map (fun x ->
-                  let* x = Fut.spawn ~on:pool_fut (fun () -> x + 1) in
-                  let* y = Fut.return (x - 1) in
-                  let+ z = Fut.spawn ~on:pool_fut (fun () -> string_of_int y) in
-                  z)
-         in
+  add_test @@ fun ~kind ->
+  let@ pool = with_pool ~kind () in
+  Q.Test.make ~name:"map bind"
+    Q.(small_list small_int)
+    (fun l ->
+      let open Fut.Infix_local in
+      let l' =
+        l
+        |> List.map (fun x ->
+               let* x = Fut.spawn ~on:pool (fun () -> x + 1) in
+               let* y = Fut.return (x - 1) in
+               let+ z = Fut.spawn ~on:pool (fun () -> string_of_int y) in
+               z)
+      in
 
-         Fut.wait_list l' |> Fut.wait_block_exn;
+      Fut.wait_list l' |> Fut.wait_block_exn;
 
-         let l_res = List.map Fut.get_or_fail_exn l' in
-         if l_res <> List.map string_of_int l then
-           Q.Test.fail_reportf "bad list: from %s, to %s"
-             Q.Print.(list int l)
-             Q.Print.(list string l_res);
-         true)
+      let l_res = List.map Fut.get_or_fail_exn l' in
+      if l_res <> List.map string_of_int l then
+        Q.Test.fail_reportf "bad list: from %s, to %s"
+          Q.Print.(list int l)
+          Q.Print.(list string l_res);
+      true)
 
-let () = QCheck_base_runner.run_tests_main !tests
+let () =
+  let tests =
+    List.map (fun t -> [ t ~kind:`Simple_pool; t ~kind:`Pool ]) !tests
+    |> List.flatten
+  in
+  QCheck_base_runner.run_tests_main tests

--- a/test/t_props.ml
+++ b/test/t_props.ml
@@ -12,10 +12,10 @@ let with_pool ~kind () f =
 
 let () =
   add_test @@ fun ~kind ->
-  let@ pool = with_pool ~kind () in
   Q.Test.make ~name:"map then join_list"
     Q.(small_list small_int)
     (fun l ->
+      let@ pool = with_pool ~kind () in
       let l' = List.map (fun x -> Fut.spawn ~on:pool (fun () -> x + 1)) l in
       let l' = Fut.join_list l' |> Fut.wait_block_exn in
       if l' <> List.map succ l then Q.Test.fail_reportf "bad list";
@@ -23,10 +23,10 @@ let () =
 
 let () =
   add_test @@ fun ~kind ->
-  let@ pool = with_pool ~kind () in
   Q.Test.make ~name:"map bind"
     Q.(small_list small_int)
     (fun l ->
+      let@ pool = with_pool ~kind () in
       let open Fut.Infix_local in
       let l' =
         l

--- a/test/t_resource.ml
+++ b/test/t_resource.ml
@@ -4,8 +4,10 @@ let ( let@ ) = ( @@ )
 
 (* test proper resource handling *)
 let () =
+  let@ () = Trace_tef.with_setup () in
   let a = Atomic.make 0 in
   for _i = 1 to 1_000 do
+    let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "loop.step" in
     (* give a chance to domains to die *)
     if _i mod 100 = 0 then Thread.delay 0.8;
 

--- a/test/t_resource.ml
+++ b/test/t_resource.ml
@@ -2,8 +2,13 @@ open! Moonpool
 
 let ( let@ ) = ( @@ )
 
+let with_pool ~kind () f =
+  match kind with
+  | `Simple_pool -> Simple_pool.with_ ~min:4 ~per_domain:1 () f
+  | `Pool -> Pool.with_ ~min:4 ~per_domain:1 () f
+
 (* test proper resource handling *)
-let () =
+let run ~kind () =
   let@ () = Trace_tef.with_setup () in
   let a = Atomic.make 0 in
   for _i = 1 to 1_000 do
@@ -12,7 +17,11 @@ let () =
     if _i mod 100 = 0 then Thread.delay 0.8;
 
     (* allocate a new pool at each iteration *)
-    let@ p = Pool.with_ ~min:4 () in
+    let@ p = with_pool ~kind () in
     Pool.run_wait_block p (fun () -> Atomic.incr a)
   done;
   assert (Atomic.get a = 1_000)
+
+let () =
+  run ~kind:`Pool ();
+  run ~kind:`Simple_pool ()

--- a/test/t_unfair.ml
+++ b/test/t_unfair.ml
@@ -1,0 +1,44 @@
+(* exhibits unfairness *)
+
+open Moonpool
+
+let ( let@ ) = ( @@ )
+
+let sleep_for f () =
+  let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "sleep" in
+  Thread.delay f
+
+let () =
+  let@ () = Trace_tef.with_setup () in
+  let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "main" in
+
+  let pool =
+    Pool.create ~min:3
+      ~on_init_thread:(fun ~dom_id:_ ~t_id () ->
+        Trace.set_thread_name (Printf.sprintf "pool worker %d" t_id))
+      ~around_task:
+        ( (fun self -> Trace.counter_int "n_tasks" (Pool.num_tasks self)),
+          fun self () -> Trace.counter_int "n_tasks" (Pool.num_tasks self) )
+      ()
+  in
+
+  (* make all threads busy *)
+  Pool.run_async pool (sleep_for 0.01);
+  Pool.run_async pool (sleep_for 0.01);
+  Pool.run_async pool (sleep_for 0.05);
+
+  let t = Unix.gettimeofday () in
+  for _i = 1 to 100 do
+    let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "schedule step" in
+    Pool.run_async pool (sleep_for 0.001);
+    Pool.run_async pool (sleep_for 0.001);
+    Pool.run_async pool (sleep_for 0.01)
+  done;
+
+  Printf.printf "pool size: %d\n%!" (Pool.num_tasks pool);
+  (let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "shutdown" in
+   Pool.shutdown pool);
+  Printf.printf "pool size after shutdown: %d\n%!" (Pool.num_tasks pool);
+
+  let elapsed = Unix.gettimeofday () -. t in
+  Printf.printf "elapsed: %.4fs\n%!" elapsed

--- a/test/t_ws_deque.ml
+++ b/test/t_ws_deque.ml
@@ -92,8 +92,35 @@ let t_heavy () =
   assert (ref_sum = sum);
   ()
 
+let t_many () =
+  print_endline "pushing many elements";
+  let d = D.create () in
+
+  let push_and_pop count =
+    for i = 1 to count do
+      (* if i mod 100_000 = 0 then Printf.printf "push %d\n%!" i; *)
+      D.push d i
+    done;
+    let n = ref 0 in
+
+    let continue = ref true in
+    while !continue do
+      match D.pop d with
+      | None -> continue := false
+      | Some _ -> incr n
+    done;
+    assert (!n = count)
+  in
+
+  push_and_pop 10_000;
+  push_and_pop 100_000;
+  push_and_pop 100_000_000;
+  print_endline "pushing many elements: ok";
+  ()
+
 let () =
   let@ () = Trace_tef.with_setup () in
   t_simple ();
   t_heavy ();
+  t_many ();
   ()

--- a/test/t_ws_deque.ml
+++ b/test/t_ws_deque.ml
@@ -1,0 +1,99 @@
+module A = Moonpool.Atomic
+module D = Moonpool.Private.Ws_deque_
+
+let ( let@ ) = ( @@ )
+
+let t_simple () =
+  let d = D.create () in
+  assert (D.steal d = None);
+  assert (D.pop d = None);
+  D.push d 1;
+  D.push d 2;
+  assert (D.pop d = Some 2);
+  assert (D.steal d = Some 1);
+  assert (D.steal d = None);
+  assert (D.pop d = None);
+  D.push d 3;
+  assert (D.pop d = Some 3);
+  D.push d 4;
+  D.push d 5;
+  D.push d 6;
+  assert (D.steal d = Some 4);
+  assert (D.steal d = Some 5);
+  assert (D.pop d = Some 6);
+  assert (D.pop d = None);
+
+  Printf.printf "basic tests passed\n";
+  ()
+
+(* big heavy test *)
+let t_heavy () =
+  let sum = A.make 0 in
+  let ref_sum = ref 0 in
+
+  let[@inline] add_to_sum x = ignore (A.fetch_and_add sum x : int) in
+
+  let active = A.make true in
+
+  let d = D.create () in
+
+  let stealer_loop () =
+    Trace.set_thread_name "stealer";
+    let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "stealer" in
+    while A.get active do
+      match D.steal d with
+      | None -> Thread.yield ()
+      | Some x -> add_to_sum x
+    done
+  in
+
+  let main_loop () =
+    Trace.set_thread_name "producer";
+    for _i = 1 to 100_000 do
+      let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "main.outer" in
+      for j = 1 to 100 do
+        ref_sum := !ref_sum + j;
+        D.push d j;
+        ref_sum := !ref_sum + j;
+        D.push d j;
+
+        Option.iter (fun x -> add_to_sum x) (D.pop d);
+        Option.iter (fun x -> add_to_sum x) (D.pop d)
+      done;
+
+      (* now compete with stealers to pop *)
+      let continue = ref true in
+      while !continue do
+        match D.pop d with
+        | Some x -> add_to_sum x
+        | None -> continue := false
+      done
+    done
+  in
+
+  let ts =
+    Array.init 6 (fun _ -> Moonpool.start_thread_on_some_domain stealer_loop ())
+  in
+  let t = Moonpool.start_thread_on_some_domain main_loop () in
+
+  (* stop *)
+  A.set active false;
+
+  Trace.message "joining t";
+  Thread.join t;
+  Trace.message "joining stealers";
+  Array.iter Thread.join ts;
+  Trace.message "done";
+
+  let ref_sum = !ref_sum in
+  let sum = A.get sum in
+
+  Printf.printf "ref sum = %d, sum = %d\n%!" ref_sum sum;
+  assert (ref_sum = sum);
+  ()
+
+let () =
+  let@ () = Trace_tef.with_setup () in
+  t_simple ();
+  t_heavy ();
+  ()


### PR DESCRIPTION
- fix pool: on shutdown, finish reading from all queues
- test: add dep on trace-tef; add new test for scheduling issues
- wip: have only one condition in pool
- fix pool: rework scheduler to use one condition
- update tests a bit
- add heavier test for a particular hangup in fork join
- restore test
- feat: add Simple_pool, with the naive single-queue implementation
- refactor: move some common code to Suspend_
- feat: add Ws_deque_
- tests for ws_deque
- perf ws_deque: implement shrinking and a push optim
- feat pool: rewrite main pool to use work stealing
- tests: run some tests on both Pool and Simple_pool
- benchs: run with both pool and simple_pool
