### PR TITLE
improve and simplify Fut

### DIFF
--- a/benchs/fib_rec.ml
+++ b/benchs/fib_rec.ml
@@ -12,7 +12,7 @@ let rec fib ~on x : int Fut.t =
   if x <= !cutoff then
     Fut.spawn ~on (fun () -> fib_direct x)
   else
-    let open Fut.Infix_local in
+    let open Fut.Infix in
     let+ t1 = fib ~on (x - 1) and+ t2 = fib ~on (x - 2) in
     t1 + t2
 

--- a/src/fut.ml
+++ b/src/fut.ml
@@ -100,6 +100,11 @@ let spawn ~on f : _ t =
   Runner.run_async on task;
   fut
 
+let spawn_on_current_runner f : _ t =
+  match Runner.get_current_runner () with
+  | None -> failwith "Fut.spawn_on_current_runner: not running on a runner"
+  | Some on -> spawn ~on f
+
 let reify_error (f : 'a t) : 'a or_error t =
   match peek f with
   | Some res -> return res

--- a/src/fut.mli
+++ b/src/fut.mli
@@ -209,7 +209,19 @@ val wait_block : 'a t -> 'a or_error
 val wait_block_exn : 'a t -> 'a
 (** Same as {!wait_block} but re-raises the exception if the future failed. *)
 
-module type INFIX = sig
+(** {2 Infix operators}
+
+    These combinators run on either the current pool (if present),
+    or on the same thread that just fulfilled the previous future
+    if not.
+
+    They were previously present as [module Infix_local] and [val infix],
+    but are now simplified.
+
+    @since NEXT_RELEASE *)
+
+(** @since NEXT_RELEASE *)
+module Infix : sig
   val ( >|= ) : 'a t -> ('a -> 'b) -> 'b t
   val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
   val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
@@ -218,17 +230,8 @@ module type INFIX = sig
   val ( and* ) : 'a t -> 'b t -> ('a * 'b) t
 end
 
-module Infix_local : INFIX
-(** Operators that run on the same thread as the first future. *)
+include module type of Infix
 
-include INFIX
-
-(** Make infix combinators, with intermediate computations running on the given pool. *)
-module Infix (_ : sig
-  val pool : Runner.t
-end) : INFIX
-
-val infix : Runner.t -> (module INFIX)
-(** [infix runner] makes a new infix module with intermediate computations
-      running on the given runner..
-    @since 0.2 *)
+module Infix_local = Infix
+[@@deprecated "Use Infix"]
+(** @deprecated use Infix instead *)

--- a/src/fut.mli
+++ b/src/fut.mli
@@ -85,6 +85,15 @@ val spawn : on:Runner.t -> (unit -> 'a) -> 'a t
 (** [spaw ~on f] runs [f()] on the given runner [on], and return a future that will
       hold its result. *)
 
+val spawn_on_current_runner : (unit -> 'a) -> 'a t
+(** This must be run from inside a runner, and schedules
+    the new task on it as well.
+
+    See {!Runner.get_current_runner} to see how the runner is found.
+
+    @since NEXT_RELEASE
+    @raise Failure if run from outside a runner. *)
+
 val reify_error : 'a t -> 'a or_error t
 (** [reify_error fut] turns a failing future into a non-failing
     one  that contain [Error (exn, bt)]. A non-failing future

--- a/src/fut.mli
+++ b/src/fut.mli
@@ -120,7 +120,7 @@ val bind_reify_error : ?on:Runner.t -> f:('a or_error -> 'b t) -> 'a t -> 'b t
     @param on if provided, [f] runs on the given runner
     @since 0.4 *)
 
-val join : ?on:Runner.t -> 'a t t -> 'a t
+val join : 'a t t -> 'a t
 (** [join fut] is [fut >>= Fun.id]. It joins the inner layer of the future.
     @since 0.2 *)
 

--- a/src/moonpool.ml
+++ b/src/moonpool.ml
@@ -5,6 +5,13 @@ let start_thread_on_some_domain f x =
 let run_async = Runner.run_async
 let recommended_thread_count () = Domain_.recommended_number ()
 let spawn = Fut.spawn
+let spawn_on_current_runner = Fut.spawn_on_current_runner
+
+[@@@ifge 5.0]
+
+let await = Fut.await
+
+[@@@endif]
 
 module Atomic = Atomic_
 module Blocking_queue = Bb_queue

--- a/src/moonpool.mli
+++ b/src/moonpool.mli
@@ -40,6 +40,19 @@ val spawn : on:Runner.t -> (unit -> 'a) -> 'a Fut.t
     and returns a future result for it. See {!Fut.spawn}.
     @since NEXT_RELEASE *)
 
+val spawn_on_current_runner : (unit -> 'a) -> 'a Fut.t
+(** See {!Fut.spawn_on_current_runner}.
+    @since NEXT_RELEASE *)
+
+[@@@ifge 5.0]
+
+val await : 'a Fut.t -> 'a
+(** Await a future. See {!Fut.await}.
+    Only on OCaml >= 5.0.
+    @since NEXT_RELEASE *)
+
+[@@@endif]
+
 module Lock = Lock
 module Fut = Fut
 module Chan = Chan

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,7 @@
 (tests
  (names
   t_fib
+  t_ws_pool_confusion
   t_bench1
   t_fib_rec
   t_futs1

--- a/test/effect-based/t_many.ml
+++ b/test/effect-based/t_many.ml
@@ -19,9 +19,7 @@ let run ~pool () =
           0 l)
   in
 
-  let futs =
-    List.init n_tasks (fun _ -> Fut.spawn ~on:pool task |> Fut.join ~on:pool)
-  in
+  let futs = List.init n_tasks (fun _ -> Fut.spawn ~on:pool task |> Fut.join) in
 
   let lens = List.map Fut.wait_block_exn futs in
   Printf.printf "awaited %d items (%d times)\n%!" (List.hd lens) n_tasks;

--- a/test/t_chan_train.ml
+++ b/test/t_chan_train.ml
@@ -3,7 +3,7 @@ open Moonpool
 (* large pool, some of our tasks below are long lived *)
 let pool = Ws_pool.create ~num_threads:30 ()
 
-open (val Fut.infix pool)
+open Fut.Infix
 
 type event =
   | E_int of int

--- a/test/t_fib_rec.ml
+++ b/test/t_fib_rec.ml
@@ -16,7 +16,7 @@ let rec fib ~on x : int Fut.t =
         Atomic.incr n_calls_fib_direct;
         fib_direct x)
   else
-    let open Fut.Infix_local in
+    let open Fut.Infix in
     let+ t1 = fib ~on (x - 1) and+ t2 = fib ~on (x - 2) in
     t1 + t2
 

--- a/test/t_props.ml
+++ b/test/t_props.ml
@@ -27,7 +27,7 @@ let () =
     Q.(small_list small_int)
     (fun l ->
       let@ pool = with_pool ~kind () in
-      let open Fut.Infix_local in
+      let open Fut.Infix in
       let l' =
         l
         |> List.map (fun x ->

--- a/test/t_tree_futs.ml
+++ b/test/t_tree_futs.ml
@@ -15,19 +15,16 @@ let rec mk_tree ~pool n : _ tree Fut.t =
   let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "mk-tree" in
   if n <= 1 then
     Fut.return (Leaf 1)
-  else
-    let open (val Fut.infix pool) in
-    let l =
-      Fut.spawn ~on:pool (fun () -> mk_tree ~pool (n - 1)) |> Fut.join ~on:pool
-    and r =
-      Fut.spawn ~on:pool (fun () -> mk_tree ~pool (n - 1)) |> Fut.join ~on:pool
-    in
+  else (
+    let l = Fut.spawn ~on:pool (fun () -> mk_tree ~pool (n - 1)) |> Fut.join
+    and r = Fut.spawn ~on:pool (fun () -> mk_tree ~pool (n - 1)) |> Fut.join in
 
     Fut.return @@ Node (l, r)
+  )
 
 let rec rev ~pool (t : 'a tree Fut.t) : 'a tree Fut.t =
   let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "rev" in
-  let open (val Fut.infix pool) in
+  let open Fut.Infix in
   t >>= function
   | Leaf n -> Fut.return (Leaf n)
   | Node (l, r) ->
@@ -36,7 +33,7 @@ let rec rev ~pool (t : 'a tree Fut.t) : 'a tree Fut.t =
 
 let rec sum ~pool (t : int tree Fut.t) : int Fut.t =
   let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "sum" in
-  let open (val Fut.infix pool) in
+  let open Fut.Infix in
   t >>= function
   | Leaf n -> Fut.return n
   | Node (l, r) ->
@@ -45,7 +42,7 @@ let rec sum ~pool (t : int tree Fut.t) : int Fut.t =
 
 let run ~pool n : (int * int) Fut.t =
   let@ _sp = Trace.with_span ~__FILE__ ~__LINE__ "run" in
-  let open (val Fut.infix pool) in
+  let open Fut.Infix in
   let t = Fut.return n >>= mk_tree ~pool in
   let t' = rev ~pool t in
   let sum_t = sum ~pool t in

--- a/test/t_ws_pool_confusion.ml
+++ b/test/t_ws_pool_confusion.ml
@@ -1,0 +1,28 @@
+open Moonpool
+
+let delay () = Thread.delay 0.001
+
+let run ~p_main:_ ~p_sub () =
+  let f1 =
+    Fut.spawn ~on:p_sub (fun () ->
+        delay ();
+        1)
+  in
+  let f2 =
+    Fut.spawn ~on:p_sub (fun () ->
+        delay ();
+        2)
+  in
+  Fut.wait_block_exn f1 + Fut.wait_block_exn f2
+
+let () =
+  let p_main = Ws_pool.create ~num_threads:2 () in
+  let p_sub = Ws_pool.create ~num_threads:10 () in
+
+  let futs = List.init 8 (fun _ -> Fut.spawn ~on:p_main (run ~p_main ~p_sub)) in
+
+  let l = List.map Fut.wait_block_exn futs in
+  assert (l = List.init 8 (fun _ -> 3));
+
+  print_endline "ok";
+  ()


### PR DESCRIPTION
Fut will now try to use the current runner if not specified otherwise; we also remove the functor for `Infix`.
